### PR TITLE
fix order of signal and battery in buffer

### DIFF
--- a/src/GW1000.js
+++ b/src/GW1000.js
@@ -97,8 +97,8 @@ class GW1000 {
                                     type: type,
                                     status: status,
                                     id: status == 'active' ? parseInt(id, 16).toString(16).toUpperCase() : null, //remove leading 0's
-                                    signal: status == 'active' ? buffer[i + 5] : null,
-                                    battery: status == 'active' ? buffer[i + 6] : null
+                                    signal: status == 'active' ? buffer[i + 6] : null,
+                                    battery: status == 'active' ? buffer[i + 5] : null
                                 });
                             }
                         }


### PR DESCRIPTION
According to [this](https://osswww.ecowitt.net/uploads/20210716/WN1900%20GW1000,1100%20WH2680,2650%20telenet%20v1.6.0%20.pdf) datasheet, `battery` is before `signal` in the buffer