### PR TITLE
fix error when a humid value is not read from liveData buffer

### DIFF
--- a/src/GW1000Utils.js
+++ b/src/GW1000Utils.js
@@ -100,7 +100,7 @@ class GW1000Utils {
         var data = {}, idx = 5;
         const size = buffer.readUInt16BE(3);
 
-        while (idx < size - 1 && idx < buffer.length - 1) {
+        while (idx < size && idx < buffer.length - 1) {
             const cix = buffer.readUInt8(idx++);
             if (DATA_STRUCT[cix] === undefined) {
                 break;


### PR DESCRIPTION
When a humid value (1 Byte) is at the end of the buffer it will not be parsed. 